### PR TITLE
Fix collapsible sidebar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -74,6 +74,11 @@ const config = {
     ({
       // Replace with your project's social card
       image: 'img/logo.png',
+      docs: {
+        sidebar: {
+          autoCollapseCategories: true,
+        },
+      },
       metadata: [{name: 'TCET Open Source', content: 'opensource, software'}],
       navbar: {
         hideOnScroll: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,11 +96,11 @@ const config = {
             label: 'Docs',
           },
           {to: '/blog', label: 'Blog', position: 'left'},
-          {
-            label: 'Join us',
-            href: 'https://bit.ly/tcetosrecruitment',
-            position: 'left',
-          },
+          // {
+          //   label: 'Join us',
+          //   href: 'https://bit.ly/tcetosrecruitment',
+          //   position: 'left',
+          // },
           {
             href: 'https://github.com/tcet-opensource/documentation',
             label: 'GitHub',


### PR DESCRIPTION
Solves #103 

This commit would collapse all sibling categories when expanding one category. This saves the user from having too many categories open and helps them focus on the selected section.