### PR TITLE
[FIX] Modified config to support read more tags and posts limitations

### DIFF
--- a/blog/2023-06-10-introduction-to-api/index.mdx
+++ b/blog/2023-06-10-introduction-to-api/index.mdx
@@ -22,6 +22,8 @@ import LaymanAPI from "./api-to-layman.png";
   <center><figcaption>APIs to a layman</figcaption></center>
 </figure>
 
+<!--truncate-->
+
 ## Introduction to API
 
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,6 +57,8 @@ const config = {
           blogTitle: "Blogs",
           blogDescription: "TCET Open Source Blogging Page",
           blogSidebarCount: 'ALL',
+          postsPerPage: 3,
+          truncateMarker: /<!--\s*(truncate)\s*-->/,
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           // editUrl:


### PR DESCRIPTION
Fixing the updated issue #108, the following things were accomplished:

1. Added a limitation to the blogs visible on the page to see only 3 posts per page, to avoid a clutter of blogs.
2. Implemented the use of `<!--truncate-->` tag to cut down the blog overflow and add a "Read More" tag to one blog.
3. Added a Regular Expression to identify truncate tags in `.mdx` files, absence of which would throw a compilation error.

Screenshots to support above fixes:

1. After every third blog, a button to view past blogs will be visible
![image](https://github.com/tcet-opensource/documentation/assets/93420999/972a0d76-9756-469f-8202-66ea2088b7ad)

2. In the following blog, only a small portion is visible on the blogs page, prompting user to open the blog to read further
![image](https://github.com/tcet-opensource/documentation/assets/93420999/dbd49092-1b98-491e-b991-80de7b626ac8)

> **Note:** On GitHub Pull Request Preview, the truncate tag would be highlighted in red, indicating error in the file's syntax. It is solely because GitHub does not use Docusaurus' config to run a compilation. However upon running `npm run build`, we have a build success, indicating no errors and a proper deployment.