### PR TITLE
FIXED About Section Typo

### DIFF
--- a/docs/about-tcetopensource.mdx
+++ b/docs/about-tcetopensource.mdx
@@ -91,7 +91,7 @@ Looking ahead, the organization has plans for upcoming projects that will furthe
 
 import Admonition from '@theme/Admonition';
 
-<Admonition type="tip" icon="📢" title="ANNOUCEMENT">
+<Admonition type="tip" icon="📢" title="ANNOUNCEMENT">
     <p>
         So if you're looking for a way to make a difference in the organization, to contribute to something greater than yourself, and to be a part of a vibrant and passionate community, look no further than this community of open source.
     </p>


### PR DESCRIPTION
## Title : FIXED Typo for About Section for title


## Issue no : 
Fixes made for : #320 

## Description
The issue reported has been successfully resolved. The bug was a minor typo in the "blogs" section where the title was misspelled with a missing letter "n" in the route "/docs/about-opensource." The appropriate spelling should have been "Announcement."

## Screenshots (if applicable)
![image](https://github.com/tcet-opensource/documentation/assets/130153710/b67cbde4-9bb2-4cc3-8446-58782f976939)


## Checklist
- [x] I have read and agree to abide by the [Code of Conduct](https://github.com/tcet-opensource/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read and followed the **Contributing Guidelines**